### PR TITLE
Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ let gallery = new Gallery(document.getElementById('gallery'), {
   - pauseOnHover: boolean, pauses autoplay when a pointing device is within the gallery area
   - draggable: boolean, allows for a basic swipe/drag to advance gallery items
   - dragThreshold: number, minimum pixel amount for a drag to advance the slideshow
+  - pagination: boolean, sets up a minimal navigation list of the gallery items
+  - paginationTarget: HTMLElement, sets up a pre-existing list to use as navigation for the gallery items. For accessibility/semantic reasons, this element is assumed to be an unordered list.
   - **THE FOLLOWING OPTIONS ARE ONLY AVAILABLE WHEN NOT USING ExecuteControllers:**
   - onLoad: fire after all images were preloaded and gallery will is initiated
   - onWillChange: fire when changing slide
   - onHasChanged: fire after changed slide
 
 If setting options via data-attributes in the markup, change camelCase to kebab-case. For example, `pauseOnHover` would become `data-pause-on-hover`.
+For custom pagination, a valid CSS selector is needed—i.e. `data-pagination-target=".my-custom-pagination"`
 
 ## Caveats
 Please note that this controller should never be stored in an immutable data structure, as doing so can lead to memory leaks due to method bindings within event listeners.

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -23,6 +23,8 @@ class Gallery extends ElementController {
    * @param {(boolean|string)} options.pauseOnHover - pauses autoplay behvior when mouse/touch enters the gallery area
    * @param {(boolean|string)} options.draggable - adds basic click-and-drag/swipe functionality to transition between gallery items
    * @param {number} options.dragThreshold - minimum distance (in pixels) for a "drag" action to occur
+   * @param {(boolean|string)} options.pagination - creates a barebones navigation list of gallery items
+   * @param {?HTMLElement} options.paginationTarget - creates a navigation list of gallery items based on the element specified. For accessibility/semantic reasons, this element is assumed to be an unordered list.
    * @param {function} options.onLoad - function to run once the gallery is loaded
    * @param {function} options.onWillChange - function to run before a gallery transition occurs
    * @param {function} options.onHasChanged - function to run after a gallery transition occurs
@@ -38,6 +40,8 @@ class Gallery extends ElementController {
       pauseOnHover: (this.element.getAttribute('data-pause-on-hover') == 'true') ? true : false,
       draggable: (this.element.getAttribute('data-draggable') == 'true') ? true : false,
       dragThreshold: (parseInt(this.element.getAttribute('data-drag-threshold')) > 0) ? parseInt(this.element.getAttribute('data-drag-threshold')) : 40,
+      pagination: (this.element.getAttribute('data-pagination') == 'true') ? true : false,
+      paginationTarget: (this.element.getAttribute('data-pagination-target') && this.element.getAttribute('data-pagination-target').length > 1) ? document.querySelector(this.element.getAttribute('data-pagination-target')) : null,
       onLoad: null,
       onWillChange: null,
       onHasChanged: null
@@ -67,6 +71,48 @@ class Gallery extends ElementController {
 
       this.element.appendChild(this.nextBtn);
       this.element.appendChild(this.prevBtn);
+    }
+
+    // If pagination is set to true, set up the item list
+    if (this.options.pagination) {
+
+      // if a nodeList was provided, use it.
+      // otherwise, build a generic list of buttons
+      if (this.options.paginationTarget) {
+
+        let itemList = this.options.paginationTarget,
+          items = itemList.querySelectorAll('li');
+
+        itemList.classList.add('gallery__pagination');
+
+        _u.forEachNode(items, (index, el) => {
+          el.classList.add('gallery__pagination-item');
+          el.addEventListener('click', this.moveByIndex.bind(this, index));
+        });
+
+      } else {
+
+        let itemList = document.createElement('ul');
+
+        _u.forEachNode(this.items, index => {
+          let item = document.createElement('li'),
+            itemBtn = document.createElement('button'),
+            itemBtnContent = document.createTextNode(index);
+
+          item.classList.add('gallery__pagination-item');
+          item.addEventListener('click', this.moveByIndex.bind(this, index));
+          
+          itemBtn.appendChild(itemBtnContent);
+          item.appendChild(itemBtn);
+          itemList.appendChild(item);
+        });
+        
+        itemList.classList.add('gallery__pagination');
+        this.element.appendChild(itemList);
+        this.paginationList = itemList;
+
+      }
+
     }
 
     // Add pause-on-hover pointer events. Including a fallback to mouse events.

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -24,7 +24,7 @@ class Gallery extends ElementController {
    * @param {(boolean|string)} options.draggable - adds basic click-and-drag/swipe functionality to transition between gallery items
    * @param {number} options.dragThreshold - minimum distance (in pixels) for a "drag" action to occur
    * @param {(boolean|string)} options.pagination - creates a barebones navigation list of gallery items
-   * @param {?HTMLElement} options.paginationTarget - creates a navigation list of gallery items based on the element specified. For accessibility/semantic reasons, this element is assumed to be an unordered list.
+   * @param {?HTMLElement} options.paginationTarget - creates a navigation list of gallery items based on the element specified.
    * @param {function} options.onLoad - function to run once the gallery is loaded
    * @param {function} options.onWillChange - function to run before a gallery transition occurs
    * @param {function} options.onHasChanged - function to run after a gallery transition occurs
@@ -81,7 +81,7 @@ class Gallery extends ElementController {
       if (this.options.paginationTarget) {
 
         let itemList = this.options.paginationTarget,
-          items = itemList.querySelectorAll('li');
+          items = itemList.children;
 
         itemList.classList.add('gallery__pagination');
 
@@ -272,8 +272,10 @@ class Gallery extends ElementController {
       return;
     }
 
-    _u.addClass('is-active is-transitioning is-transitioning--center', next);
-    _u.removeClass('is-active', this.currentItem);
+    if (this.currentItem != next) {
+      _u.addClass('is-active is-transitioning is-transitioning--center', next);
+      _u.removeClass('is-active', this.currentItem);
+    }
 
     if (typeof this.options.onHasChanged == "function") {
       this.options.onHasChanged(next, this.currentItem);


### PR DESCRIPTION
Added some basic pagination options.

If you specify `pagination: true` (or `data-pagination="true"`), you'll get a basic unordered list containing buttons for each list item.

If you specify a `paginationTarget` (used in the markup as `data-pagination-target=".my-cool-list"`), pagination will be generated based on the list you specify. This is assumed to be an unordered list, going in. Note that `pagination` must also be set to true for this to work.