### PR TITLE
Allow next/prev button and live region content strings to be passed in via data-attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtc-gallery-component",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Very simplistic gallery with image preloader and a navigation and autoplay option.",
   "main": "dist/wtc-gallery-component.js",
   "style": "dist/wtc-gallery-component.css",

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -48,9 +48,9 @@ class Gallery extends ElementController {
       dragThreshold: (parseInt(this.element.getAttribute('data-drag-threshold')) > 0) ? parseInt(this.element.getAttribute('data-drag-threshold')) : 40,
       pagination: (this.element.getAttribute('data-pagination') == 'true') ? true : false,
       paginationTarget: (this.element.getAttribute('data-pagination-target') && this.element.getAttribute('data-pagination-target').length > 1) ? this.element.getAttribute('data-pagination-target') : null,
-      nextBtnMarkup: 'Next <span class="visually-hidden">carousel item.</span>',
-      prevBtnMarkup: 'Previous <span class="visually-hidden">carousel item.</span>',
-      liveRegionText: 'Active carousel item',
+      nextBtnMarkup: this.element.getAttribute('data-next-btn-markup') ? this.element.getAttribute('data-next-btn-markup') : 'Next <span class="visually-hidden">carousel item.</span>',
+      prevBtnMarkup: this.element.getAttribute('data-prev-btn-markup') ? this.element.getAttribute('data-prev-btn-markup') : 'Previous <span class="visually-hidden">carousel item.</span>',
+      liveRegionText: this.element.getAttribute('data-live-region-text') ? this.element.getAttribute('data-live-region-text') : 'Active carousel item',
       onLoad: null,
       onWillChange: null,
       onHasChanged: null


### PR DESCRIPTION
Previously, these options had to be specified in the constructor, and consequently, were not easily editable for localization purposes. This change allows you to specify these options in data-attributes on the element. Working example: https://codepen.io/team/wtc/pen/a9440bc256e6fa222cbec1f1105767d9