### PR TITLE
Fixed disabled button logic

### DIFF
--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -460,8 +460,6 @@ class Gallery extends ElementController {
     this.currentIndex = +next.dataset.index;
 
     if (!this.options.loop && this.options.nav) {
-      console.log(this.currentIndex);
-
       if (this.currentIndex == this.items.length - 1) {
         this.nextBtn.setAttribute("disabled", true);
         this.prevBtn.removeAttribute("disabled");

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -403,8 +403,10 @@ class Gallery extends ElementController {
     if (!this.options.loop && this.options.nav) {
       if (this.currentIndex == this.items.length - 1) {
         this.nextBtn.setAttribute("disabled", true);
+        this.prevBtn.removeAttribute("disabled");
       } else if (this.currentIndex == 0) {
         this.prevBtn.setAttribute("disabled", true);
+        this.nextBtn.removeAttribute("disabled");
       } else {
         this.nextBtn.removeAttribute("disabled");
         this.prevBtn.removeAttribute("disabled");
@@ -458,10 +460,14 @@ class Gallery extends ElementController {
     this.currentIndex = +next.dataset.index;
 
     if (!this.options.loop && this.options.nav) {
+      console.log(this.currentIndex);
+
       if (this.currentIndex == this.items.length - 1) {
         this.nextBtn.setAttribute("disabled", true);
+        this.prevBtn.removeAttribute("disabled");
       } else if (this.currentIndex == 0) {
         this.prevBtn.setAttribute("disabled", true);
+        this.nextBtn.removeAttribute("disabled");
       } else {
         this.nextBtn.removeAttribute("disabled");
         this.prevBtn.removeAttribute("disabled");


### PR DESCRIPTION
# Issue
If there are two items in the gallery component, and you have non-looping navigation buttons, the disabled states break as soon as you press "next".

# Solution
Inside the `move()` and `moveByIndex()` methods:
Remove the Previous and Next buttons' `disabled` attributes in the `if` and `else if` blocks, respectively.

You can edit the working version of this in CodePen, by removing all but two gallery items: https://codepen.io/team/wtc/pen/a9440bc256e6fa222cbec1f1105767d9