### PR TITLE
Remove wtc-utility-helpers dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,13 @@
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
+    "babel-loader": "^8.0.5",
     "webpack": "^4.28.1",
-    "webpack-cli": "^3.2.1",
-    "babel-loader": "^8.0.5"
+    "webpack-cli": "^3.2.1"
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.0",
     "wtc-controller-element": "^1.0.7",
-    "wtc-utility-helpers": "^1.1.2",
     "wtc-utility-preloader": "^1.0.2"
   }
 }

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -94,8 +94,8 @@ class Gallery extends ElementController {
       this.prevBtn = document.createElement("button");
       this.prevBtn.innerHTML = this.options.prevBtnMarkup;
 
-      this.nextBtn.classList.add("gallery__nav gallery__nav-next");
-      this.prevBtn.classList.add("gallery__nav gallery__nav-prev");
+      this.nextBtn.className = "gallery__nav gallery__nav-next";
+      this.prevBtn.className = "gallery__nav gallery__nav-prev";
 
       this.nextBtn.addEventListener("click", this.next.bind(this));
       this.prevBtn.addEventListener("click", this.prev.bind(this));
@@ -353,10 +353,10 @@ class Gallery extends ElementController {
    * @return {class} This.
    */
   itemTransitioned(item) {
-    item.classList.remove(
-      "is-transitioning is-transitioning--center is-transitioning--backward is-transitioning--forward"
-    );
-
+    item.classList.remove("is-transitioning");
+    item.classList.remove("is-transitioning--center");
+    item.classList.remove("is-transitioning--backward");
+    item.classList.remove("is-transitioning--forward");
     return this;
   }
 
@@ -380,7 +380,9 @@ class Gallery extends ElementController {
     if (this.currentItem != next) {
       this.currentItem.setAttribute("aria-hidden", "true");
       next.removeAttribute("aria-hidden");
-      next.classList.add("is-active is-transitioning is-transitioning--center");
+      next.classList.add("is-active");
+      next.classList.add("is-transitioning");
+      next.classList.add("is-transitioning--center");
       this.currentItem.classList.remove("is-active");
     }
 
@@ -443,7 +445,9 @@ class Gallery extends ElementController {
       next = direction ? this.items[0] : this.items[this.items.length - 1];
     }
 
-    next.classList.add("is-active is-transitioning is-transitioning--center");
+    next.classList.add("is-active");
+    next.classList.add("is-transitioning");
+    next.classList.add("is-transitioning--center");
     this.currentItem.classList.remove("is-active");
 
     this.currentItem.setAttribute("aria-hidden", "true");
@@ -495,9 +499,8 @@ class Gallery extends ElementController {
     }
 
     this.currentItem.classList.remove("is-transitioning--center");
-    this.currentItem.classList.add(
-      "is-transitioning is-transitioning--backward"
-    );
+    this.currentItem.classList.add("is-transitioning");
+    this.currentItem.classList.add("is-transitioning--backward");
 
     this.move();
 
@@ -516,9 +519,8 @@ class Gallery extends ElementController {
     }
 
     this.currentItem.classList.remove("is-transitioning--center");
-    this.currentItem.classList.add(
-      "is-transitioning is-transitioning--forward"
-    );
+    this.currentItem.classList.add("is-transitioning");
+    this.currentItem.classList.add("is-transitioning--forward");
 
     this.move(false);
 

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -82,7 +82,7 @@ class Gallery extends ElementController {
     if (options) this.options = Object.assign({}, this.options, options);
 
     this.wrapper = this.element.querySelector("ul");
-    this.items = this.wrapper.children;
+    this.items = [...this.wrapper.children];
     this.overlay = document.createElement("div");
     this.currentItem = this.items[0];
     this.currentIndex = 0;
@@ -112,9 +112,9 @@ class Gallery extends ElementController {
       // otherwise, build a generic list of buttons
       if (this.options.paginationTarget) {
         itemList = document.querySelector(this.options.paginationTarget);
-        let items = itemList.children;
+        let items = [...itemList.children];
 
-        items.forEach((element, index) => {
+        items.forEach((el, index) => {
           el.classList.add("gallery__pagination-item");
           if (!el.dataset.index) el.dataset.index = index;
           if (index === 0) el.classList.add("is-active");
@@ -132,8 +132,8 @@ class Gallery extends ElementController {
             itemBtnContent = document.createTextNode(i);
 
           item.classList.add("gallery__pagination-item");
-          item.dataset.index = index;
-          if (index === 0) item.classList.add("is-active");
+          item.dataset.index = i;
+          if (i === 0) item.classList.add("is-active");
           item.addEventListener("click", this.handlePagination.bind(this));
 
           itemBtn.appendChild(itemBtnContent);
@@ -145,7 +145,7 @@ class Gallery extends ElementController {
       }
 
       this.paginationList = itemList;
-      this.paginationItems = itemList.children;
+      this.paginationItems = [...this.paginationList.children];
       itemList.classList.add("gallery__pagination");
     }
 
@@ -255,7 +255,7 @@ class Gallery extends ElementController {
     if (target) {
       let i = +target.dataset.index;
 
-      this.paginationList.children.forEach((item, index) => {
+      this.paginationItems.forEach((item, index) => {
         if (i === index) item.classList.add("is-active");
         else item.classList.remove("is-active");
       });

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -114,10 +114,10 @@ class Gallery extends ElementController {
         itemList = document.querySelector(this.options.paginationTarget);
         let items = [...itemList.children];
 
-        items.forEach((el, index) => {
+        items.forEach((el, i) => {
           el.classList.add("gallery__pagination-item");
-          if (!el.dataset.index) el.dataset.index = index;
-          if (index === 0) el.classList.add("is-active");
+          if (!el.dataset.index) el.dataset.index = i;
+          if (i === 0) el.classList.add("is-active");
           el.addEventListener("click", this.handlePagination.bind(this));
         });
       } else {
@@ -129,7 +129,7 @@ class Gallery extends ElementController {
         for (i; i < length; i++) {
           let item = document.createElement("li"),
             itemBtn = document.createElement("button"),
-            itemBtnContent = document.createTextNode(i);
+            itemBtnContent = document.createTextNode(i + 1);
 
           item.classList.add("gallery__pagination-item");
           item.dataset.index = i;
@@ -200,12 +200,12 @@ class Gallery extends ElementController {
     this.overlay.classList.add("gallery__overlay");
     this.wrapper.classList.add("gallery__wrapper");
 
-    this.items.forEach((item, index) => {
+    this.items.forEach((item, i) => {
       item.classList.add("gallery__item");
-      item.dataset.index = index;
+      item.dataset.index = i;
       item.setAttribute("tabindex", -1);
 
-      if (this.currentIndex !== index) {
+      if (this.currentIndex !== i) {
         // "hide" any focusable children on inactive elements
         let focusableChildren = item.querySelectorAll(
           "button, [href], [tabindex]"
@@ -253,13 +253,13 @@ class Gallery extends ElementController {
   handlePagination(e) {
     let target = e.target.closest(".gallery__pagination-item");
     if (target) {
-      let i = +target.dataset.index;
+      let paginationIndex = +target.dataset.index;
 
-      this.paginationItems.forEach((item, index) => {
-        if (i === index) item.classList.add("is-active");
+      this.paginationItems.forEach((item, i) => {
+        if (paginationIndex === i) item.classList.add("is-active");
         else item.classList.remove("is-active");
       });
-      this.moveByIndex(i);
+      this.moveByIndex(paginationIndex);
 
       // shift focus to active item. note this should only happen on pagination click,
       // not on next/prev click https://www.w3.org/WAI/tutorials/carousels/functionality/#announce-the-current-item
@@ -454,8 +454,8 @@ class Gallery extends ElementController {
     next.removeAttribute("aria-hidden");
 
     if (this.options.pagination) {
-      this.paginationItems.forEach((item, index) => {
-        if (index == next.dataset.index) item.classList.add("is-active");
+      this.paginationItems.forEach((item, i) => {
+        if (i == next.dataset.index) item.classList.add("is-active");
         else item.classList.remove("is-active");
       });
     }

--- a/src/wtc-gallery-component.js
+++ b/src/wtc-gallery-component.js
@@ -8,7 +8,6 @@
  * @created Nov 30, 2016
  */
 
-import _u from "wtc-utility-helpers";
 import Preloader from "wtc-utility-preloader";
 import {
   default as ElementController,
@@ -95,8 +94,8 @@ class Gallery extends ElementController {
       this.prevBtn = document.createElement("button");
       this.prevBtn.innerHTML = this.options.prevBtnMarkup;
 
-      _u.addClass("gallery__nav gallery__nav-next", this.nextBtn);
-      _u.addClass("gallery__nav gallery__nav-prev", this.prevBtn);
+      this.nextBtn.classList.add("gallery__nav gallery__nav-next");
+      this.prevBtn.classList.add("gallery__nav gallery__nav-prev");
 
       this.nextBtn.addEventListener("click", this.next.bind(this));
       this.prevBtn.addEventListener("click", this.prev.bind(this));
@@ -115,21 +114,24 @@ class Gallery extends ElementController {
         itemList = document.querySelector(this.options.paginationTarget);
         let items = itemList.children;
 
-        _u.forEachNode(items, (index, el) => {
+        items.forEach((element, index) => {
           el.classList.add("gallery__pagination-item");
           if (!el.dataset.index) el.dataset.index = index;
           if (index === 0) el.classList.add("is-active");
           el.addEventListener("click", this.handlePagination.bind(this));
         });
       } else {
+        let i = 0,
+          length = this.items.length;
+
         itemList = document.createElement("ul");
 
-        _u.forEachNode(this.items, index => {
+        for (i; i < length; i++) {
           let item = document.createElement("li"),
             itemBtn = document.createElement("button"),
-            itemBtnContent = document.createTextNode(index);
+            itemBtnContent = document.createTextNode(i);
 
-          _u.addClass("gallery__pagination-item", item);
+          item.classList.add("gallery__pagination-item");
           item.dataset.index = index;
           if (index === 0) item.classList.add("is-active");
           item.addEventListener("click", this.handlePagination.bind(this));
@@ -137,7 +139,7 @@ class Gallery extends ElementController {
           itemBtn.appendChild(itemBtnContent);
           item.appendChild(itemBtn);
           itemList.appendChild(item);
-        });
+        }
 
         this.element.appendChild(itemList);
       }
@@ -152,7 +154,7 @@ class Gallery extends ElementController {
     if (this.options.liveRegionText) {
       this.liveRegion = document.createElement("p");
       this.liveRegion.setAttribute("aria-live", "polite");
-      _u.addClass("visually-hidden", this.liveRegion);
+      this.liveRegion.classList.add("visually-hidden");
       this.element.insertAdjacentElement("afterbegin", this.liveRegion);
     }
 
@@ -194,12 +196,12 @@ class Gallery extends ElementController {
     }
 
     // add base classes
-    _u.addClass("gallery", this.element);
-    _u.addClass("gallery__overlay", this.overlay);
-    _u.addClass("gallery__wrapper", this.wrapper);
+    this.element.classList.add("gallery");
+    this.overlay.classList.add("gallery__overlay");
+    this.wrapper.classList.add("gallery__wrapper");
 
-    _u.forEachNode(this.items, (index, item) => {
-      _u.addClass("gallery__item", item);
+    this.items.forEach((item, index) => {
+      item.classList.add("gallery__item");
       item.dataset.index = index;
       item.setAttribute("tabindex", -1);
 
@@ -208,9 +210,10 @@ class Gallery extends ElementController {
         let focusableChildren = item.querySelectorAll(
           "button, [href], [tabindex]"
         );
-        _u.forEachNode(focusableChildren, (i, focusable) => {
-          focusable.setAttribute("tabindex", -1);
-        });
+
+        for (let focusableEl of focusableChildren) {
+          focusableEl.setAttribute("tabindex", -1);
+        }
 
         item.setAttribute("aria-hidden", "true");
       }
@@ -222,8 +225,8 @@ class Gallery extends ElementController {
     });
 
     // add state classes
-    _u.addClass("is-active", this.currentItem);
-    _u.addClass("is-loading", this.element);
+    this.currentItem.classList.add("is-active");
+    this.element.classList.add("is-loading");
 
     // append main element
     this.element.appendChild(this.overlay);
@@ -233,9 +236,9 @@ class Gallery extends ElementController {
     if (images.length > 0) {
       let preloader = new Preloader({ debug: this.options.debug });
 
-      _u.forEachNode(images, (index, item) => {
+      for (let item of images) {
         preloader.add(item.getAttribute("src"), "image");
-      });
+      }
 
       preloader.load(this.loaded.bind(this));
     } else {
@@ -251,9 +254,10 @@ class Gallery extends ElementController {
     let target = e.target.closest(".gallery__pagination-item");
     if (target) {
       let i = +target.dataset.index;
-      _u.forEachNode(this.paginationList.children, (index, item) => {
-        if (i === index) _u.addClass("is-active", item);
-        else _u.removeClass("is-active", item);
+
+      this.paginationList.children.forEach((item, index) => {
+        if (i === index) item.classList.add("is-active");
+        else item.classList.remove("is-active");
       });
       this.moveByIndex(i);
 
@@ -305,12 +309,12 @@ class Gallery extends ElementController {
   resize() {
     let newH = 0;
 
-    _u.forEachNode(this.items, (index, item) => {
+    for (let item of this.items) {
       let h = item.offsetHeight;
       if (h > newH) {
         newH = h;
       }
-    });
+    }
 
     this.wrapper.style.height = `${newH}px`;
 
@@ -325,8 +329,8 @@ class Gallery extends ElementController {
     window.addEventListener("resize", this.resize.bind(this));
     this.resize();
 
-    _u.removeClass("is-loading", this.element);
-    _u.addClass("is-loaded", this.element);
+    this.element.classList.remove("is-loading");
+    this.element.classList.add("is-loaded");
 
     if (this.options.autoplay) {
       this.player = setTimeout(this.next.bind(this), this.options.delay);
@@ -349,9 +353,8 @@ class Gallery extends ElementController {
    * @return {class} This.
    */
   itemTransitioned(item) {
-    _u.removeClass(
-      "is-transitioning is-transitioning--center is-transitioning--backward is-transitioning--forward",
-      item
+    item.classList.remove(
+      "is-transitioning is-transitioning--center is-transitioning--backward is-transitioning--forward"
     );
 
     return this;
@@ -377,18 +380,18 @@ class Gallery extends ElementController {
     if (this.currentItem != next) {
       this.currentItem.setAttribute("aria-hidden", "true");
       next.removeAttribute("aria-hidden");
-      _u.addClass("is-active is-transitioning is-transitioning--center", next);
-      _u.removeClass("is-active", this.currentItem);
+      next.classList.add("is-active is-transitioning is-transitioning--center");
+      this.currentItem.classList.remove("is-active");
     }
 
     if (this.options.pagination) {
-      _u.forEachNode(this.paginationItems, (counter, item) => {
+      for (let item of this.paginationItems) {
         if (item.dataset.index == index) {
-          _u.addClass("is-active", item);
+          item.classList.add("is-active");
         } else {
-          _u.removeClass("is-active", item);
+          item.classList.remove("is-active");
         }
-      });
+      }
     }
 
     if (this.liveRegion && this.options.liveRegionText) {
@@ -440,16 +443,16 @@ class Gallery extends ElementController {
       next = direction ? this.items[0] : this.items[this.items.length - 1];
     }
 
-    _u.addClass("is-active is-transitioning is-transitioning--center", next);
-    _u.removeClass("is-active", this.currentItem);
+    next.classList.add("is-active is-transitioning is-transitioning--center");
+    this.currentItem.classList.remove("is-active");
 
     this.currentItem.setAttribute("aria-hidden", "true");
     next.removeAttribute("aria-hidden");
 
     if (this.options.pagination) {
-      _u.forEachNode(this.paginationItems, (index, item) => {
-        if (index == next.dataset.index) _u.addClass("is-active", item);
-        else _u.removeClass("is-active", item);
+      this.paginationItems.forEach((item, index) => {
+        if (index == next.dataset.index) item.classList.add("is-active");
+        else item.classList.remove("is-active");
       });
     }
 
@@ -491,10 +494,9 @@ class Gallery extends ElementController {
       this.options.onWillChange(this, true);
     }
 
-    _u.removeClass("is-transitioning--center", this.currentItem);
-    _u.addClass(
-      "is-transitioning is-transitioning--backward",
-      this.currentItem
+    this.currentItem.classList.remove("is-transitioning--center");
+    this.currentItem.classList.add(
+      "is-transitioning is-transitioning--backward"
     );
 
     this.move();
@@ -513,8 +515,10 @@ class Gallery extends ElementController {
       this.options.onWillChange(this, false);
     }
 
-    _u.removeClass("is-transitioning--center", this.currentItem);
-    _u.addClass("is-transitioning is-transitioning--forward", this.currentItem);
+    this.currentItem.classList.remove("is-transitioning--center");
+    this.currentItem.classList.add(
+      "is-transitioning is-transitioning--forward"
+    );
 
     this.move(false);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3822,11 +3822,6 @@ wtc-controller-element@^1.0.7:
   resolved "https://registry.yarnpkg.com/wtc-controller-element/-/wtc-controller-element-1.1.1.tgz#9b6233d9a5343ef942e778e77f7bd73b4403a103"
   integrity sha512-QmHUAjppVUCyo8fbkF9ngZBBjjhEWgjJRBDcgwqoU3Ngd4EL4m0nT7exTQ7OIyu+eUweSUv0o3O+Q7M73g2Rkg==
 
-wtc-utility-helpers@^1.1.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/wtc-utility-helpers/-/wtc-utility-helpers-1.3.2.tgz#519166e882b282f1732067d15fcc6b79666afac0"
-  integrity sha512-APuWttPiRhThqk53++fCg9scwvWe5T/hPxPmdMFDcOqfbxvwZjQNVPWdD3i8zKA/+WL3wRW9CVYgUsId9OffNw==
-
 wtc-utility-preloader@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/wtc-utility-preloader/-/wtc-utility-preloader-1.0.5.tgz#7fd63862f00c7a04c08255edc779df3147101e1d"


### PR DESCRIPTION
# Description
Remove the `wtc-utility-helpers` dependency, and make the following changes as a result:
- Change all addClass and removeClass calls to `classList.add` and `classList.remove`, respectively.
- Change calls to forEachNode to one of the following, where appropriate: `for, `for of`, or `forEach`.
- Spread HTMLCollections into Arrays where necessary, in order to expose the `.forEach` interface. For example, on the pagination items: `paginationElement.children`.