### PR TITLE
Adds z-index: 1; to active gallery slide

### DIFF
--- a/src/wtc-gallery-component.scss
+++ b/src/wtc-gallery-component.scss
@@ -64,6 +64,11 @@
     transform: scale(1) translateY(-50%);
     z-index: 1;
 
+    /*
+      z-index added to make clickable elements
+      within the active slide usable.
+    */
+
     /* focusable child elements */
     button,
     [href],

--- a/src/wtc-gallery-component.scss
+++ b/src/wtc-gallery-component.scss
@@ -62,6 +62,7 @@
   &.is-active {
     opacity: 1;
     transform: scale(1) translateY(-50%);
+    z-index: 1;
 
     /* focusable child elements */
     button,


### PR DESCRIPTION
## Description

Currently when we have a gallery with clickable elements within (links, buttons) they aren't usable as the slides are positioned absolute on top of each other. Recently in projects I've found myself adding a `z-index: 1;` to the `.gallery__item` with the `.is-active` class. Figured maybe it was worth baking this into the library. Let me know what you think.

## Screenshots

An example on DC where this was an issue. Only the first `meet ____` button was clickable due to the absolutely positioned slides.

<img width="1796" alt="Screenshot 2021-08-18 at 9 38 14 AM" src="https://user-images.githubusercontent.com/5969303/129938698-c6ce9b78-af4d-4821-873e-93daaefe6263.png">
